### PR TITLE
Push wheels to s3

### DIFF
--- a/.github/workflows/seasmon_xr.yaml
+++ b/.github/workflows/seasmon_xr.yaml
@@ -87,3 +87,26 @@ jobs:
           name: wheels
           path: wheels
           if-no-files-found: error
+
+      - name: upload wheels to S3
+        if: |
+          github.event_name == 'push'
+          && matrix.python-version == 3.8
+          && (github.ref_name == 'main' || github.ref_name == 'push-s3')
+
+        run: |
+          aws s3 sync wheels/ ${S3_DEST}/
+
+          # re-render index.html
+          aws s3 ls ${S3_DEST}/ | ./scripts/render-simple-index.awk > wheels/index.html
+          # need to copy it as index.html into "directory"
+          aws s3 cp wheels/index.html ${S3_DEST}/index.html
+          # but also as a file with the same name as directory,
+          # so that `curl http://${host}/pypi/seasmon-xr` works
+          aws s3 cp wheels/index.html ${S3_DEST} --content-type text/html
+
+        env:
+          S3_DEST: s3://wfp-share/pypi/seasmon-xr
+          AWS_DEFAULT_REGION: eu-central-1
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/scripts/render-simple-index.awk
+++ b/scripts/render-simple-index.awk
@@ -1,0 +1,18 @@
+#!/usr/bin/awk -f
+#
+# Generate "simple pypi index" from s3 directory listing
+#
+# > aws s3 ls s3://bucket/path/ | ./render-simple-index.awk | tee index.html
+#
+BEGIN {
+   print "<!DOCTYPE html>"
+   print "<html><body>"
+}
+
+/.*\.whl/ , /.*\.gz/ {
+  print "  <a href=\"" $4 "\">" $4 "</a></br>"
+}
+
+END {
+    print "</body></html>"
+}


### PR DESCRIPTION
With this change any merge into `main` branch will upload wheel to `s3://wfp-share/pypi/seasmon-xr/`.

to install latest dev version from there:

```bash
env host=wfp-share.s3-website.eu-central-1.amazonaws.com \
  pip install \
    --trusted-host ${host} \
    --extra-index-url=http://${host}/pypi/ \
    "seasmon_xr >=0.1.2.dev88"
```


Or as `requirements.txt`
```
--trusted-host=wfp-share.s3-website.eu-central-1.amazonaws.com
--extra-index-url=http://wfp-share.s3-website.eu-central-1.amazonaws.com/pypi/
seasmon_xr >=0.1.2.dev88
```
