### PR TITLE
`.spi` datatype bugfix

### DIFF
--- a/hdc/algo/accessors.py
+++ b/hdc/algo/accessors.py
@@ -453,8 +453,8 @@ class PixelAlgorithms(AccessorBase):
 
     def spi(
         self,
-        calibration_start=None,
-        calibration_stop=None,
+        calibration_start: Optional[str] = None,
+        calibration_stop: Optional[str] = None,
     ):
         """Calculate the SPI along the time dimension."""
         if not self._check_for_timedim():

--- a/hdc/algo/ops/stats.py
+++ b/hdc/algo/ops/stats.py
@@ -202,8 +202,9 @@ def gammastd_yxt(
     cal_start=None,
     cal_stop=None,
 ):
-    """Calculate gammastd on 3d y,x,t array."""
-    y = np.full_like(x, -9999, dtype=x.dtype)
+    """Calculate `gammastd` on 3d y,x,t array.
+    `gammastd` outputs are scaled by 1000 and cast to in16."""
+    y = np.full_like(x, -9999, dtype="int16")
     r, c, t = x.shape
 
     if cal_start is None:

--- a/hdc/algo/ops/stats.py
+++ b/hdc/algo/ops/stats.py
@@ -203,7 +203,11 @@ def gammastd_yxt(
     cal_stop=None,
 ):
     """Calculate `gammastd` on 3d y,x,t array.
-    `gammastd` outputs are scaled by 1000 and cast to in16."""
+
+    The function `gammastd` is applied over 3d each row and column
+    of the array with the assumption the time dimension is the last one.
+    The outputs are scaled by 1000 and cast to in16.
+    """
     y = np.full_like(x, -9999, dtype="int16")
     r, c, t = x.shape
 


### PR DESCRIPTION
Prevent spi output to be cast into incompatible datatype by enforcing `int16`.

