### PR TITLE
Grouped operations (and more)

### DIFF
--- a/hdc/algo/_version.py
+++ b/hdc/algo/_version.py
@@ -1,2 +1,2 @@
 """Version only in this file."""
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/hdc/algo/accessors.py
+++ b/hdc/algo/accessors.py
@@ -524,6 +524,10 @@ class PixelAlgorithms(AccessorBase):
             groups = np.array(groups) if not isinstance(groups, np.ndarray) else groups
             num_groups = np.unique(groups).size
 
+            if not groups.dtype.name == "int16":
+                warn("Casting groups to int16!")
+                groups = groups.astype("int16")
+
             res = xarray.apply_ufunc(
                 gammastd_grp,
                 self._obj,

--- a/hdc/algo/accessors.py
+++ b/hdc/algo/accessors.py
@@ -450,6 +450,7 @@ class PixelAlgorithms(AccessorBase):
         calibration_stop: Optional[str] = None,
         nodata: Optional[Union[float, int]] = None,
         groups: Optional[Iterable[int]] = None,
+        dtype="int16",
     ):
         """Calculate the SPI along the time dimension.
 
@@ -518,6 +519,7 @@ class PixelAlgorithms(AccessorBase):
                 output_core_dims=[["time"]],
                 keep_attrs=True,
                 dask="parallelized",
+                dask_gufunc_kwargs={"meta": self._obj.data.astype(dtype)},
             )
 
         else:
@@ -540,7 +542,7 @@ class PixelAlgorithms(AccessorBase):
                 output_core_dims=[["time"]],
                 keep_attrs=True,
                 dask="parallelized",
-                dask_gufunc_kwargs={"meta": self._obj.data},
+                dask_gufunc_kwargs={"meta": self._obj.data.astype(dtype)},
             )
 
         res.attrs.update(

--- a/hdc/algo/accessors.py
+++ b/hdc/algo/accessors.py
@@ -640,6 +640,26 @@ class PixelAlgorithms(AccessorBase):
         return x
 
 
+class RollingWindowAlgos(AccessorBase):
+    """Class to calculate rolling window algos on dimenson."""
+
+    def sum(self, window_size: int, dimension: str = "time"):
+        # pylint: disable=import-outside-toplevel
+        from .ops.stats import rolling_sum
+
+        xx = xarray.apply_ufunc(
+            rolling_sum,
+            self._obj,
+            window_size,
+            input_core_dims=[[dimension], []],
+            output_core_dims=[[dimension]],
+            dask="parallelized",
+            dask_gufunc_kwargs={"meta": self._obj.data},
+        )
+        xx = xx[..., window_size - 1 :]
+        return xx
+
+
 class ZonalStatistics(AccessorBase):
     """Class to claculate zonal statistics."""
 
@@ -736,5 +756,6 @@ class HDC:
         self.algo = PixelAlgorithms(xarray_obj)
         self.anom = Anomalies(xarray_obj)
         self.iteragg = IterativeAggregation(xarray_obj)
+        self.rolling = RollingWindowAlgos(xarray_obj)
         self.whit = WhittakerSmoother(xarray_obj)
         self.zonal = ZonalStatistics(xarray_obj)

--- a/hdc/algo/accessors.py
+++ b/hdc/algo/accessors.py
@@ -718,7 +718,7 @@ class ZonalStatistics(AccessorBase):
         self,
         zones: xarray.DataArray,
         zone_ids: Union[List, np.ndarray],
-        dtype: str = "float64",
+        dtype: str = "float32",
         dim_name: str = "zones",
         name: Optional[str] = None,
     ) -> xarray.DataArray:
@@ -764,6 +764,9 @@ class ZonalStatistics(AccessorBase):
             "stat": ["mean", "valid"],
         }
 
+        # convert str datatype to type
+        dtype = np.dtype(dtype).type
+
         if is_dask_collection(xx):
             dask_name = name
             if isinstance(dask_name, str):
@@ -781,7 +784,7 @@ class ZonalStatistics(AccessorBase):
                 drop_axis=[1, 2],
                 new_axis=[1, 2],
                 chunks=chunks,
-                dtype=dtype,
+                out_dtype=dtype,
                 name=dask_name,
             )
         else:
@@ -791,6 +794,7 @@ class ZonalStatistics(AccessorBase):
                 num_zones,
                 xx.nodata,
                 zones.nodata,
+                out_dtype=dtype,
             )
 
         return xarray.DataArray(

--- a/hdc/algo/accessors.py
+++ b/hdc/algo/accessors.py
@@ -1,5 +1,5 @@
 """Xarray Accesor classes."""
-from typing import List, Optional, Union
+from typing import Iterable, List, Optional, Union
 from warnings import warn
 
 from dask import is_dask_collection
@@ -444,7 +444,7 @@ class PixelAlgorithms(AccessorBase):
         self,
         calibration_start: Optional[str] = None,
         calibration_stop: Optional[str] = None,
-        groups: Optional[List[int]] = None,
+        groups: Optional[Iterable[int]] = None,
     ):
         """Calculate the SPI along the time dimension.
 
@@ -460,10 +460,11 @@ class PixelAlgorithms(AccessorBase):
         if not self._check_for_timedim():
             raise MissingTimeError("SPI requires a time dimension!")
 
+        # pylint: disable=import-outside-toplevel
         from .ops.stats import (
             gammastd_yxt,
             gammastd_grp,
-        )  # pylint: disable=import-outside-toplevel
+        )
 
         tix = self._obj.get_index("time")
 

--- a/hdc/algo/accessors.py
+++ b/hdc/algo/accessors.py
@@ -504,6 +504,7 @@ class PixelAlgorithms(AccessorBase):
                 },
                 input_core_dims=[["time"]],
                 output_core_dims=[["time"]],
+                keep_attrs=True,
                 dask="parallelized",
             )
 
@@ -520,6 +521,7 @@ class PixelAlgorithms(AccessorBase):
                 calstop_ix,
                 input_core_dims=[["time"], ["grps"], [], [], []],
                 output_core_dims=[["time"]],
+                keep_attrs=True,
                 dask="parallelized",
                 dask_gufunc_kwargs={"meta": self._obj.data},
             )
@@ -556,6 +558,7 @@ class PixelAlgorithms(AccessorBase):
             input_core_dims=[["time"]],
             dask="parallelized",
             output_dtypes=["uint8"],
+            keep_attrs=True,
         )
 
     def autocorr(self):

--- a/hdc/algo/accessors.py
+++ b/hdc/algo/accessors.py
@@ -101,6 +101,10 @@ class Period(AccessorTimeBase):
         return self._tseries.apply(lambda x: self._period_cls(x).yidx).to_xarray()
 
     @property
+    def ndays(self):
+        return self._tseries.apply(lambda x: self._period_cls(x).ndays).to_xarray()
+
+    @property
     def label(self):
         return self._tseries.apply(lambda x: str(self._period_cls(x))).to_xarray()
 

--- a/hdc/algo/accessors.py
+++ b/hdc/algo/accessors.py
@@ -108,6 +108,18 @@ class Period(AccessorTimeBase):
     def label(self):
         return self._tseries.apply(lambda x: str(self._period_cls(x))).to_xarray()
 
+    @property
+    def start_date(self):
+        return self._tseries.apply(lambda x: self._period_cls(x).start_date).to_xarray()
+
+    @property
+    def end_date(self):
+        return self._tseries.apply(lambda x: self._period_cls(x).end_date).to_xarray()
+
+    @property
+    def raw(self):
+        return self._tseries.apply(lambda x: self._period_cls(x).raw).to_xarray()
+
 
 @xarray.register_dataset_accessor("dekad")
 @xarray.register_dataarray_accessor("dekad")

--- a/hdc/algo/accessors.py
+++ b/hdc/algo/accessors.py
@@ -684,6 +684,7 @@ class PixelAlgorithms(AccessorBase):
             nodata,
             input_core_dims=[["time"], ["grps"], [], []],
             output_core_dims=[["time"]],
+            keep_attrs=True,
             dask="parallelized",
             dask_gufunc_kwargs={"meta": self._obj.data},
         )
@@ -702,6 +703,7 @@ class RollingWindowAlgos(AccessorBase):
             window_size,
             input_core_dims=[[dimension], []],
             output_core_dims=[[dimension]],
+            keep_attrs=True,
             dask="parallelized",
             dask_gufunc_kwargs={"meta": self._obj.data},
         )

--- a/hdc/algo/ops/stats.py
+++ b/hdc/algo/ops/stats.py
@@ -469,14 +469,16 @@ def _mann_kendall_trend_gu(x, tau, p, slope, trend):
     tau[0], p[0], slope[0], trend[0] = mann_kendall_trend_1d(x)
 
 
-@guvectorize(
-    [
-        "(float32[:], int16[:], float64, float64, float32[:])",
-        "(int16[:], int16[:], float64, float64, float32[:])",
-        "(int32[:], int16[:], float64, float64, float32[:])",
-        "(int64[:], int16[:], float64, float64, float32[:])",
-    ],
-    "(n),(m),(),() -> (n)",
+@lazycompile(
+    guvectorize(
+        [
+            "(float32[:], int16[:], float64, float64, float32[:])",
+            "(int16[:], int16[:], float64, float64, float32[:])",
+            "(int32[:], int16[:], float64, float64, float32[:])",
+            "(int64[:], int16[:], float64, float64, float32[:])",
+        ],
+        "(n),(m),(),() -> (n)",
+    )
 )
 def mean_grp(xx, groups, num_groups, nodata, yy):
     """Calculate grouped mean."""
@@ -500,13 +502,15 @@ def mean_grp(xx, groups, num_groups, nodata, yy):
         yy[grp_ix] = avg
 
 
-@guvectorize(
-    [
-        "(float32[:], float64, float32[:])",
-        "(int16[:], float64, float32[:])",
-        "(int64[:], float64, float32[:])",
-    ],
-    "(n),() -> (n)",
+@lazycompile(
+    guvectorize(
+        [
+            "(float32[:], float64, float32[:])",
+            "(int16[:], float64, float32[:])",
+            "(int64[:], float64, float32[:])",
+        ],
+        "(n),() -> (n)",
+    )
 )
 def rolling_sum(xx, window_size, yy):
     """Calculate moving window sum over specified size."""

--- a/hdc/algo/ops/stats.py
+++ b/hdc/algo/ops/stats.py
@@ -505,21 +505,24 @@ def mean_grp(xx, groups, num_groups, nodata, yy):
 @lazycompile(
     guvectorize(
         [
-            "(float32[:], float64, float32[:])",
-            "(int16[:], float64, float32[:])",
-            "(int64[:], float64, float32[:])",
+            "(float32[:], float64, float64, float32[:])",
+            "(int16[:], float64, float64, float32[:])",
+            "(int64[:], float64, float64, float32[:])",
         ],
-        "(n),() -> (n)",
+        "(n),(),() -> (n)",
     )
 )
-def rolling_sum(xx, window_size, yy):
+def rolling_sum(xx, window_size, nodata, yy):
     """Calculate moving window sum over specified size."""
     n = xx.size
-    yy[:] = 0.0
+    yy[:] = 0
     for ii in range(n):
         if ii - window_size + 1 < 0:
-            yy[ii] = 0.0
+            yy[ii] = nodata
             continue
 
         for jj in range(ii - window_size + 1, ii + 1):
+            if xx[jj] == nodata:
+                yy[ii] = nodata
+                continue
             yy[ii] += xx[jj]

--- a/hdc/algo/ops/stats.py
+++ b/hdc/algo/ops/stats.py
@@ -240,8 +240,8 @@ def gammastd_grp(xx, groups, num_groups, cal_start, cal_stop, yy):
 
     This calculates gammastd across xx for indivual groups
     defined in `groups`. These need to be in ascending order from
-    0 to num_groups - 1."""
-
+    0 to num_groups - 1.
+    """
     for grp in range(num_groups):
         grp_ix = groups == grp
         pix = xx[grp_ix]
@@ -492,3 +492,17 @@ def mean_grp(xx, groups, num_groups, nodata, yy):
             avg = avg / n
 
         yy[grp_ix] = avg
+
+
+@guvectorize(["(float32[:], float64, float32[:])"], "(n),() -> (n)")
+def rolling_sum(xx, window_size, yy):
+    """Calculate moving window sum over specified size."""
+    n = xx.size
+    yy[:] = 0.0
+    for ii in range(n):
+        if ii - window_size + 1 < 0:
+            yy[ii] = 0.0
+            continue
+
+        for jj in range(ii - window_size + 1, ii + 1):
+            yy[ii] += xx[jj]

--- a/hdc/algo/ops/stats.py
+++ b/hdc/algo/ops/stats.py
@@ -470,7 +470,13 @@ def _mann_kendall_trend_gu(x, tau, p, slope, trend):
 
 
 @guvectorize(
-    ["(float32[:], int16[:], float64, float64, float32[:])"], "(n),(m),(),() -> (n)"
+    [
+        "(float32[:], int16[:], float64, float64, float32[:])",
+        "(int16[:], int16[:], float64, float64, float32[:])",
+        "(int32[:], int16[:], float64, float64, float32[:])",
+        "(int64[:], int16[:], float64, float64, float32[:])",
+    ],
+    "(n),(m),(),() -> (n)",
 )
 def mean_grp(xx, groups, num_groups, nodata, yy):
     """Calculate grouped mean."""

--- a/hdc/algo/ops/stats.py
+++ b/hdc/algo/ops/stats.py
@@ -467,3 +467,28 @@ def _mann_kendall_trend_gu_nd(x, nodata, tau, p, slope, trend):
 def _mann_kendall_trend_gu(x, tau, p, slope, trend):
     """Guvectorize wrapper for mann_kendall_trend_1d."""
     tau[0], p[0], slope[0], trend[0] = mann_kendall_trend_1d(x)
+
+
+@guvectorize(
+    ["(float32[:], int16[:], float64, float64, float32[:])"], "(n),(m),(),() -> (n)"
+)
+def mean_grp(xx, groups, num_groups, nodata, yy):
+    """Calculate grouped mean."""
+    for grp in range(num_groups):
+        grp_ix = groups == grp
+        pix = xx[grp_ix]
+        n = 0
+        for pixv in pix:
+            if pixv == nodata:
+                continue
+            if n == 0:
+                avg = pixv
+            else:
+                avg += pixv
+            n += 1
+        if n == 0:
+            avg = nodata
+        else:
+            avg = avg / n
+
+        yy[grp_ix] = avg

--- a/hdc/algo/ops/stats.py
+++ b/hdc/algo/ops/stats.py
@@ -494,7 +494,14 @@ def mean_grp(xx, groups, num_groups, nodata, yy):
         yy[grp_ix] = avg
 
 
-@guvectorize(["(float32[:], float64, float32[:])"], "(n),() -> (n)")
+@guvectorize(
+    [
+        "(float32[:], float64, float32[:])",
+        "(int16[:], float64, float32[:])",
+        "(int64[:], float64, float32[:])",
+    ],
+    "(n),() -> (n)",
+)
 def rolling_sum(xx, window_size, yy):
     """Calculate moving window sum over specified size."""
     n = xx.size

--- a/hdc/algo/ops/zonal.py
+++ b/hdc/algo/ops/zonal.py
@@ -6,7 +6,7 @@ from ._helper import lazycompile
 
 
 @lazycompile(njit)
-def do_mean(pixels, z_pixels, num_zones, nodata, z_nodata, dtype="float64"):
+def do_mean(pixels, z_pixels, num_zones, nodata, z_nodata, out_dtype=np.float32):
     """Calculate the zonal mean.
 
     The mean for each pixel of `pixels` is calculated for each zone in
@@ -22,11 +22,11 @@ def do_mean(pixels, z_pixels, num_zones, nodata, z_nodata, dtype="float64"):
         z_pixels: zonal pixels (Y,X)
         nodata: nodata value in values
         num_zones: number of zones in z_pixels
-        dtype: datatype
+        out_dtype: datatype
     """
     t, nr, nc = pixels.shape
+    result = np.zeros((t, num_zones, 2), dtype=out_dtype)
 
-    result = np.zeros((t, num_zones, 2), dtype=dtype)
     # 0 mean
     # 1 valids
 

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -894,7 +894,7 @@ def test_zonal_mean(darr, zones):
                 [[63.0, 2.0], [16.0, 2.0]],
             ]
         ),
-        dtype="float64",
+        dtype="float32",
     )
 
     z_ids = np.unique(zones.data)
@@ -903,6 +903,7 @@ def test_zonal_mean(darr, zones):
     np.testing.assert_equal(x.coords["zones"].data, [0, 1])
     assert list(x.coords["stat"].values) == ["mean", "valid"]
     np.testing.assert_almost_equal(x, res)
+    assert x.dtype == res.dtype
 
 
 def test_zonal_mean_nodata(darr, zones):
@@ -914,7 +915,7 @@ def test_zonal_mean_nodata(darr, zones):
             [[28.0, 2.0], [12.0, 2.0]],
             [[63.0, 2.0], [16.0, 2.0]],
         ],
-        dtype="float64",
+        dtype="float32",
     )
 
     darr[0, 0, 0] = darr.nodata
@@ -922,6 +923,7 @@ def test_zonal_mean_nodata(darr, zones):
     z_ids = np.unique(zones.data)
     x = darr.hdc.zonal.mean(zones, z_ids)
     np.testing.assert_almost_equal(x, res)
+    assert x.dtype == res.dtype
 
 
 def test_zonal_mean_nodata_nan(darr, zones):
@@ -949,8 +951,9 @@ def test_zonal_mean_nodata_nan_float(darr, zones):
     darr[0, 0, 0] = "nan"
 
     z_ids = np.unique(zones.data)
-    x = darr.hdc.zonal.mean(zones, z_ids)
+    x = darr.hdc.zonal.mean(zones, z_ids, dtype="float64")
     np.testing.assert_almost_equal(x, res)
+    assert x.dtype == res.dtype
 
 
 def test_zonal_zone_nodata_nan(darr, zones):
@@ -967,13 +970,14 @@ def test_zonal_zone_nodata_nan(darr, zones):
 
     zones.attrs = {"nodata": 0}
     z_ids = np.unique(zones.data)
-    x = darr.hdc.zonal.mean(zones, z_ids, dim_name="foo")
+    x = darr.hdc.zonal.mean(zones, z_ids, dim_name="foo", dtype="float64")
     np.testing.assert_almost_equal(x, res)
+    assert x.dtype == res.dtype
 
 
 def test_zonal_dimname(darr, zones):
     z_ids = np.unique(zones.data)
-    x = darr.hdc.zonal.mean(zones, z_ids, dim_name="foo")
+    x = darr.hdc.zonal.mean(zones, z_ids, dim_name="foo", dtype="float64")
     assert x.dims == ("time", "foo", "stat")
 
 

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -1008,6 +1008,14 @@ def test_rolling_sum(darr):
     )
 
 
+def test_rolling_sum_nodata(darr):
+    darr[:, 0, 0] = -9999
+    xr.testing.assert_allclose(
+        darr.hdc.rolling.sum(3, nodata=-9999).transpose("time", ...),
+        darr.rolling(time=3).sum().where(darr != -9999, -9999).dropna("time"),
+    )
+
+
 def test_mean_grp(darr):
     grps = np.array([0, 0, 1, 1, 2], dtype="int16")
     tst = darr.hdc.algo.mean_grp(grps)[..., [0, 2, 4]]

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -995,3 +995,10 @@ def test_zonal_type_exc(darr, zones):
     z_ids = np.unique(zones.data)
     with pytest.raises(ValueError):
         _ = darr.hdc.zonal.mean(zones.data, z_ids)
+
+
+def test_rolling_sum(darr):
+    xr.testing.assert_allclose(
+        darr.hdc.rolling.sum(window_size=3).transpose("time", ...),
+        darr.rolling(time=3).sum().dropna("time"),
+    )

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -73,6 +73,13 @@ def test_period_yidx_dekad(darr):
     np.testing.assert_array_equal(darr.time.dekad.yidx, [1, 2, 3, 3, 4])
 
 
+def test_period_ndays_dekad(darr):
+    assert isinstance(darr.time.dekad.ndays, xr.DataArray)
+    np.testing.assert_equal(
+        darr.time.dekad.ndays.values, np.array([10, 10, 11, 11, 10])
+    )
+
+
 def test_period_labels_dekad(darr):
     assert isinstance(darr.time.dekad.label, xr.DataArray)
     np.testing.assert_array_equal(

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -1016,15 +1016,17 @@ def test_zonal_type_exc(darr, zones):
 
 
 def test_rolling_sum(darr):
-    xr.testing.assert_allclose(
-        darr.hdc.rolling.sum(window_size=3).transpose("time", ...),
+    res = darr.hdc.rolling.sum(window_size=3).transpose("time", ...)
+    xr.testing.assert_equal(
+        res,
         darr.rolling(time=3).sum().dropna("time"),
     )
+    np.testing.assert_equal(darr[-3:].sum("time").data, res[-1].data)
 
 
 def test_rolling_sum_nodata(darr):
     darr[:, 0, 0] = -9999
-    xr.testing.assert_allclose(
+    xr.testing.assert_equal(
         darr.hdc.rolling.sum(3, nodata=-9999).transpose("time", ...),
         darr.rolling(time=3).sum().where(darr != -9999, -9999).dropna("time"),
     )

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -229,6 +229,13 @@ def test_algo_spi_decoupled_3(darr):
     assert _res.attrs["spi_calibration_stop"] == "2000-02-10"
 
 
+def test_algo_spi_nodata(darr):
+    _ = darr.attrs.pop("nodata")
+    with pytest.raises(ValueError):
+        _ = darr.hdc.algo.spi()
+    _ = darr.hdc.algo.spi(nodata=-9999)
+
+
 def test_algo_spi_decoupled_err_1(darr):
     with pytest.raises(ValueError):
         _res = darr.hdc.algo.spi(

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -80,6 +80,47 @@ def test_period_ndays_dekad(darr):
     )
 
 
+def test_period_start_date_dekad(darr):
+    assert isinstance(darr.time.dekad.start_date, xr.DataArray)
+    np.testing.assert_equal(
+        darr.time.dekad.start_date.values,
+        np.array(
+            [
+                "2000-01-01T00:00:00.000000000",
+                "2000-01-11T00:00:00.000000000",
+                "2000-01-21T00:00:00.000000000",
+                "2000-01-21T00:00:00.000000000",
+                "2000-02-01T00:00:00.000000000",
+            ],
+            dtype="datetime64[ns]",
+        ),
+    )
+
+
+def test_period_end_date_dekad(darr):
+    assert isinstance(darr.time.dekad.end_date, xr.DataArray)
+    np.testing.assert_equal(
+        darr.time.dekad.end_date.values,
+        np.array(
+            [
+                "2000-01-10T23:59:59.999999000",
+                "2000-01-20T23:59:59.999999000",
+                "2000-01-31T23:59:59.999999000",
+                "2000-01-31T23:59:59.999999000",
+                "2000-02-10T23:59:59.999999000",
+            ],
+            dtype="datetime64[ns]",
+        ),
+    )
+
+
+def test_period_raw_dekad(darr):
+    assert isinstance(darr.time.dekad.raw, xr.DataArray)
+    np.testing.assert_array_equal(
+        darr.time.dekad.raw, [72000, 72001, 72002, 72002, 72003]
+    )
+
+
 def test_period_labels_dekad(darr):
     assert isinstance(darr.time.dekad.label, xr.DataArray)
     np.testing.assert_array_equal(

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -1002,3 +1002,24 @@ def test_rolling_sum(darr):
         darr.hdc.rolling.sum(window_size=3).transpose("time", ...),
         darr.rolling(time=3).sum().dropna("time"),
     )
+
+
+def test_mean_grp(darr):
+    grps = np.array([0, 0, 1, 1, 2], dtype="int16")
+    tst = darr.hdc.algo.mean_grp(grps)[..., [0, 2, 4]]
+    cntrl = (
+        darr.groupby(xr.DataArray(grps, dims=("time",))).mean().transpose(..., "group")
+    )
+
+    np.testing.assert_allclose(tst.data, cntrl.data)
+
+
+def test_mean_grp_exc(darr):
+    grps = np.array([0, 0, 1, 1, 2], dtype="int16")
+    _darr = darr.copy()
+    _ = _darr.attrs.pop("nodata")
+    with pytest.raises(ValueError):
+        _darr.hdc.algo.mean_grp(grps)
+
+    with pytest.raises(MissingTimeError):
+        darr.rename(time="foo").hdc.algo.mean_grp(grps)

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -145,6 +145,12 @@ def test_algo_spi(darr, res_spi):
     np.testing.assert_array_equal(_res, res_spi)
 
 
+def test_algo_spi_grouped(darr, res_spi):
+    _res = darr.astype("float32").hdc.algo.spi(groups=np.array([0] * 5, dtype="int16"))
+    assert isinstance(_res, xr.DataArray)
+    np.testing.assert_array_equal(_res, res_spi)
+
+
 def test_algo_spi_transp(darr, res_spi):
     _darr = darr.transpose(..., "time")
     _res = _darr.hdc.algo.spi()

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -96,7 +96,7 @@ def test_gammafit(ts):
 
 
 def test_gammastd(ts):
-    xspi = gammastd_yxt.py_func(ts.reshape(1, 1, -1))
+    xspi = gammastd_yxt.py_func(ts.reshape(1, 1, -1), -9999)
     assert xspi.shape == (1, 1, 10)
     np.testing.assert_array_equal(
         xspi[0, 0, :],
@@ -105,7 +105,7 @@ def test_gammastd(ts):
 
 
 def test_gammastd(ts):
-    xspi = gammastd.py_func(ts, 0, 10)
+    xspi = gammastd.py_func(ts, -9999, 0, 10)
 
     np.testing.assert_array_equal(
         (xspi * 1000).round(),
@@ -114,7 +114,7 @@ def test_gammastd(ts):
 
 
 def test_gammastd_nofit(ts):
-    xspi = gammastd.py_func(ts, 0, len(ts), a=1, b=2)
+    xspi = gammastd.py_func(ts, -9999, 0, len(ts), a=1, b=2)
     xspi
     np.testing.assert_array_equal(
         (xspi * 1000).round(),
@@ -134,7 +134,7 @@ def test_gammastd_nofit(ts):
 
 
 def test_gammastd_selfit(ts):
-    xspi = gammastd_yxt.py_func(ts.reshape(1, 1, -1), cal_start=0, cal_stop=3)
+    xspi = gammastd_yxt.py_func(ts.reshape(1, 1, -1), -9999, cal_start=0, cal_stop=3)
     assert xspi.shape == (1, 1, 10)
     np.testing.assert_array_equal(
         xspi[0, 0, :],
@@ -156,9 +156,12 @@ def test_gammastd_selfit(ts):
 def test_gammastd_selfit_2(ts):
     cal_start = 2
     cal_stop = 8
+    nodata = -9999
     a, b = gammafit.py_func(ts[cal_start:cal_stop])
-    xspi_ref = gammastd.py_func(ts, cal_start=cal_start, cal_stop=cal_stop, a=a, b=b)
-    xspi = gammastd.py_func(ts, cal_start=cal_start, cal_stop=cal_stop)
+    xspi_ref = gammastd.py_func(
+        ts, nodata, cal_start=cal_start, cal_stop=cal_stop, a=a, b=b
+    )
+    xspi = gammastd.py_func(ts, nodata, cal_start=cal_start, cal_stop=cal_stop)
     np.testing.assert_equal(xspi, xspi_ref)
 
 

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -30,6 +30,7 @@ from hdc.algo.ops.stats import (
     mk_variance_s,
     mk_sens_slope,
     mann_kendall_trend_1d,
+    rolling_sum,
 )
 
 
@@ -187,6 +188,16 @@ def test_mean_grp(ts):
     grps = np.tile(np.arange(5), 10).astype("int16")
     res = mean_grp(tts, grps, np.unique(grps).size, 0)
     assert (res == 1.02697).all()
+
+
+def test_rolling_sum():
+    res = rolling_sum(np.arange(10).astype("float32"), 3)
+    np.testing.assert_almost_equal(
+        res,
+        np.array(
+            [0.0, 0.0, 3.0, 6.0, 9.0, 12.0, 15.0, 18.0, 21.0, 24.0], dtype="float32"
+        ),
+    )
 
 
 def test_ws2dgu(ts):

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -92,7 +92,7 @@ def test_gammafit(ts):
     assert parameters == pytest.approx((1.083449238500003, 0.9478709674697126))
 
 
-def test_spi(ts):
+def test_gammastd(ts):
     xspi = gammastd_yxt.py_func(ts.reshape(1, 1, -1))
     assert xspi.shape == (1, 1, 10)
     np.testing.assert_array_equal(
@@ -101,7 +101,16 @@ def test_spi(ts):
     )
 
 
-def test_spi_nofit(ts):
+def test_gammastd(ts):
+    xspi = gammastd.py_func(ts, 0, 10)
+
+    np.testing.assert_array_equal(
+        (xspi * 1000).round(),
+        [-382.0, 1654.0, 588.0, 207.0, -1097.0, -1098.0, -1677.0, 1094.0, 213.0, 514.0],
+    )
+
+
+def test_gammastd_nofit(ts):
     xspi = gammastd.py_func(ts, 0, len(ts), a=1, b=2)
     xspi
     np.testing.assert_array_equal(
@@ -121,7 +130,7 @@ def test_spi_nofit(ts):
     )
 
 
-def test_spi_selfit(ts):
+def test_gammastd_selfit(ts):
     xspi = gammastd_yxt.py_func(ts.reshape(1, 1, -1), cal_start=0, cal_stop=3)
     assert xspi.shape == (1, 1, 10)
     np.testing.assert_array_equal(
@@ -141,7 +150,7 @@ def test_spi_selfit(ts):
     )
 
 
-def test_spi_selfit_2(ts):
+def test_gammastd_selfit_2(ts):
     cal_start = 2
     cal_stop = 8
     a, b = gammafit.py_func(ts[cal_start:cal_stop])

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -23,6 +23,7 @@ from hdc.algo.ops.stats import (
     gammastd,
     gammastd_yxt,
     gammastd_grp,
+    mean_grp,
     mk_score,
     mk_p_value,
     mk_z_score,
@@ -178,7 +179,14 @@ def test_gammastd_grp(ts):
         0.5144766,
     ]
 
-    np.testing.assert_almost_equal(xspi, np.repeat(res, 5))
+    np.testing.assert_almost_equal(xspi, (np.repeat(res, 5) * 1000).round())
+
+
+def test_mean_grp(ts):
+    tts = np.repeat(ts, 5).astype("float32")
+    grps = np.tile(np.arange(5), 10).astype("int16")
+    res = mean_grp(tts, grps, np.unique(grps).size, 0)
+    assert (res == 1.02697).all()
 
 
 def test_ws2dgu(ts):

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -165,7 +165,7 @@ def test_gammastd_selfit_2(ts):
 def test_gammastd_grp(ts):
     tts = np.repeat(ts, 5).astype("float32")
     grps = np.tile(np.arange(5), 10).astype("int16")
-    xspi = gammastd_grp(tts, grps, np.unique(grps).size, 0, 10)
+    xspi = gammastd_grp(tts, grps, np.unique(grps).size, 0, 0, 10)
 
     res = [
         -0.38238713,

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -22,6 +22,7 @@ from hdc.algo.ops.stats import (
     gammafit,
     gammastd,
     gammastd_yxt,
+    gammastd_grp,
     mk_score,
     mk_p_value,
     mk_z_score,
@@ -157,6 +158,27 @@ def test_gammastd_selfit_2(ts):
     xspi_ref = gammastd.py_func(ts, cal_start=cal_start, cal_stop=cal_stop, a=a, b=b)
     xspi = gammastd.py_func(ts, cal_start=cal_start, cal_stop=cal_stop)
     np.testing.assert_equal(xspi, xspi_ref)
+
+
+def test_gammastd_grp(ts):
+    tts = np.repeat(ts, 5).astype("float32")
+    grps = np.tile(np.arange(5), 10).astype("int16")
+    xspi = gammastd_grp(tts, grps, np.unique(grps).size, 0, 10)
+
+    res = [
+        -0.38238713,
+        1.6544422,
+        0.5879236,
+        0.20665395,
+        -1.0974495,
+        -1.0975538,
+        -1.6773673,
+        1.093621,
+        0.21322519,
+        0.5144766,
+    ]
+
+    np.testing.assert_almost_equal(xspi, np.repeat(res, 5))
 
 
 def test_ws2dgu(ts):

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -191,7 +191,7 @@ def test_mean_grp(ts):
 
 
 def test_rolling_sum():
-    res = rolling_sum(np.arange(10).astype("float32"), 3)
+    res = rolling_sum(np.arange(10).astype("float32"), 3, 0)
     np.testing.assert_almost_equal(
         res,
         np.array(


### PR DESCRIPTION
This PR came from improvement work done for pre-calculating SPIs and such for admin extractions.

Most notably this PR adds:

- computation of groups along time dimension
    - ` gammastd_grp` for grouped SPIs, that can be calculated by passing an array with group indices to the `.algo.spi` accessor
    - `mean_grp` grouped means (accessible through `algo.mean_grp` accessor)
- a new accessor `rolling` that allows for rolling computations over a defined window. Currently, `rolling.sum` is implemented
- a fix for `zonal.mean` which prevented the definition of output datatype 