### PR TITLE
Vendor numba-scipy

### DIFF
--- a/conda/recipe-meta/meta.yaml
+++ b/conda/recipe-meta/meta.yaml
@@ -21,7 +21,6 @@ requirements:
   run:
     - python >=3.7
     - {{ pin_compatible('hdc-algo-core', max_pin='x.x.x') }}
-    - numba-scipy >=0.3.1
     - scipy
 
 test:

--- a/dev-env.yml
+++ b/dev-env.yml
@@ -1,6 +1,6 @@
 # Setup instructions:
 #   > mamba env create -f dev-env.yml
-#   > conda activate vam-hdc-algo
+#   > conda activate hdc-algo
 #   > pip install -e .
 #   > pytest -s tests/
 name: hdc-algo
@@ -8,8 +8,8 @@ channels:
   - conda-forge
 
 dependencies:
-  - python =3.9
-  - pip =20
+  - python =3.10
+  - pip =23
 
   # hdc-algo dependencies
   - xarray
@@ -17,7 +17,6 @@ dependencies:
   - numba
   - dask[array]
   - scipy
-  - numba-scipy >=0.3.0
 
   # tests and dev
   ## to use from jupyter-lab: `python -m ipykernel install --user --name vam-seasmon`
@@ -33,10 +32,6 @@ dependencies:
   - pycodestyle
   - pylint
   - docutils
-  ### shed dependencies
-  - pyyaml
-  - pyupgrade
-  - libcst
 
   ## test
   - pytest

--- a/hdc/algo/_version.py
+++ b/hdc/algo/_version.py
@@ -1,2 +1,2 @@
 """Version only in this file."""
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/hdc/algo/ops/stats.py
+++ b/hdc/algo/ops/stats.py
@@ -2,11 +2,13 @@
 from math import erf, log, sqrt
 
 import numba
-import numba_scipy  # pylint: disable=unused-import
 import numpy as np
 import scipy.special as sc
 
+from ..vendor.numba_scipy import _init_extension
 from ._helper import lazycompile
+
+_init_extension()
 
 
 @numba.njit

--- a/hdc/algo/vendor/numba_scipy/LICENSE
+++ b/hdc/algo/vendor/numba_scipy/LICENSE
@@ -1,0 +1,24 @@
+Copyright (c) 2019, Anaconda, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/hdc/algo/vendor/numba_scipy/README.rst
+++ b/hdc/algo/vendor/numba_scipy/README.rst
@@ -1,0 +1,25 @@
+***********
+numba-scipy
+***********
+
+.. image:: https://badges.gitter.im/numba/numba.svg
+   :target: https://gitter.im/numba/numba?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge
+   :alt: Gitter
+
+Numba + SciPy = numba-scipy
+###########################
+
+``numba-scipy`` extends Numba to make it aware of SciPy. Numba is an open
+source, NumPy-aware optimizing compiler for Python sponsored by Anaconda, Inc.
+It uses the LLVM compiler project to generate machine code from Python syntax.
+
+For more information about Numba, see the Numba homepage:
+http://numba.pydata.org
+
+For more information about numba-scipy see:
+https://numba-scipy.readthedocs.io/en/latest/index.html
+
+Dependencies
+============
+
+* numba

--- a/hdc/algo/vendor/numba_scipy/__init__.py
+++ b/hdc/algo/vendor/numba_scipy/__init__.py
@@ -1,0 +1,7 @@
+def _init_extension():
+    """Register SciPy functions with Numba.
+
+    This entry_point is called by Numba when it initializes.
+    """
+    # pylint: disable=unused-import,import-outside-toplevel
+    from . import sparse, special

--- a/hdc/algo/vendor/numba_scipy/sparse.py
+++ b/hdc/algo/vendor/numba_scipy/sparse.py
@@ -1,0 +1,225 @@
+import warnings
+import numpy as np
+import scipy as sp
+import scipy.sparse
+from numba import types
+
+try:
+    from numba.core import cgutils
+    from numba.core.imputils import impl_ret_borrowed
+except ImportError:
+    from numba import cgutils
+    from numba.targets.imputils import impl_ret_borrowed
+
+try:
+    from numba.core.errors import NumbaExperimentalFeatureWarning
+except ImportError:
+    from numba.errors import NumbaWarning
+
+    class NumbaExperimentalFeatureWarning(NumbaWarning):
+        pass
+
+
+from numba.extending import (
+    NativeValue,
+    box,
+    intrinsic,
+    make_attribute_wrapper,
+    models,
+    overload,
+    overload_attribute,
+    overload_method,
+    register_model,
+    typeof_impl,
+    unbox,
+)
+
+
+class CSMatrixType(types.Type):
+    """A Numba `Type` modeled after the base class `scipy.sparse.compressed._cs_matrix`."""
+
+    name: str
+
+    @staticmethod
+    def instance_class(data, indices, indptr, shape):
+        raise NotImplementedError()
+
+    def __init__(self, dtype):
+        warnings.warn(
+            "Use of sparse matrices detected. This is an experimental feature.",
+            category=NumbaExperimentalFeatureWarning,
+        )
+        self.dtype = dtype
+        self.data = types.Array(dtype, 1, "A")
+        self.indices = types.Array(types.int32, 1, "A")
+        self.indptr = types.Array(types.int32, 1, "A")
+        self.shape = types.UniTuple(types.int64, 2)
+        super().__init__(self.name)
+
+    @property
+    def key(self):
+        return (self.name, self.dtype)
+
+
+make_attribute_wrapper(CSMatrixType, "data", "data")
+make_attribute_wrapper(CSMatrixType, "indices", "indices")
+make_attribute_wrapper(CSMatrixType, "indptr", "indptr")
+make_attribute_wrapper(CSMatrixType, "shape", "shape")
+
+
+class CSRMatrixType(CSMatrixType):
+    name = "csr_matrix"
+
+    @staticmethod
+    def instance_class(data, indices, indptr, shape):
+        return sp.sparse.csr_matrix((data, indices, indptr), shape, copy=False)
+
+
+class CSCMatrixType(CSMatrixType):
+    name = "csc_matrix"
+
+    @staticmethod
+    def instance_class(data, indices, indptr, shape):
+        return sp.sparse.csc_matrix((data, indices, indptr), shape, copy=False)
+
+
+@typeof_impl.register(sp.sparse.csc_matrix)
+def typeof_csc_matrix(val, c):
+    data = typeof_impl(val.data, c)
+    return CSCMatrixType(data.dtype)
+
+
+@typeof_impl.register(sp.sparse.csr_matrix)
+def typeof_csr_matrix(val, c):
+    data = typeof_impl(val.data, c)
+    return CSRMatrixType(data.dtype)
+
+
+@register_model(CSRMatrixType)
+class CSRMatrixModel(models.StructModel):
+    def __init__(self, dmm, fe_type):
+        members = [
+            ("data", fe_type.data),
+            ("indices", fe_type.indices),
+            ("indptr", fe_type.indptr),
+            ("shape", fe_type.shape),
+        ]
+        super().__init__(dmm, fe_type, members)
+
+
+@register_model(CSCMatrixType)
+class CSCMatrixModel(models.StructModel):
+    def __init__(self, dmm, fe_type):
+        members = [
+            ("data", fe_type.data),
+            ("indices", fe_type.indices),
+            ("indptr", fe_type.indptr),
+            ("shape", fe_type.shape),
+        ]
+        super().__init__(dmm, fe_type, members)
+
+
+@unbox(CSCMatrixType)
+@unbox(CSRMatrixType)
+def unbox_matrix(typ, obj, c):
+
+    struct_ptr = cgutils.create_struct_proxy(typ)(c.context, c.builder)
+
+    data = c.pyapi.object_getattr_string(obj, "data")
+    indices = c.pyapi.object_getattr_string(obj, "indices")
+    indptr = c.pyapi.object_getattr_string(obj, "indptr")
+    shape = c.pyapi.object_getattr_string(obj, "shape")
+
+    struct_ptr.data = c.unbox(typ.data, data).value
+    struct_ptr.indices = c.unbox(typ.indices, indices).value
+    struct_ptr.indptr = c.unbox(typ.indptr, indptr).value
+    struct_ptr.shape = c.unbox(typ.shape, shape).value
+
+    c.pyapi.decref(data)
+    c.pyapi.decref(indices)
+    c.pyapi.decref(indptr)
+    c.pyapi.decref(shape)
+
+    is_error_ptr = cgutils.alloca_once_value(c.builder, cgutils.false_bit)
+    is_error = c.builder.load(is_error_ptr)
+
+    res = NativeValue(struct_ptr._getvalue(), is_error=is_error)
+
+    return res
+
+
+@box(CSCMatrixType)
+@box(CSRMatrixType)
+def box_matrix(typ, val, c):
+    struct_ptr = cgutils.create_struct_proxy(typ)(c.context, c.builder, value=val)
+
+    data_obj = c.box(typ.data, struct_ptr.data)
+    indices_obj = c.box(typ.indices, struct_ptr.indices)
+    indptr_obj = c.box(typ.indptr, struct_ptr.indptr)
+    shape_obj = c.box(typ.shape, struct_ptr.shape)
+
+    c.pyapi.incref(data_obj)
+    c.pyapi.incref(indices_obj)
+    c.pyapi.incref(indptr_obj)
+    c.pyapi.incref(shape_obj)
+
+    cls_obj = c.pyapi.unserialize(c.pyapi.serialize_object(typ.instance_class))
+    obj = c.pyapi.call_function_objargs(
+        cls_obj, (data_obj, indices_obj, indptr_obj, shape_obj)
+    )
+
+    c.pyapi.decref(data_obj)
+    c.pyapi.decref(indices_obj)
+    c.pyapi.decref(indptr_obj)
+    c.pyapi.decref(shape_obj)
+
+    return obj
+
+
+@overload(np.shape)
+def overload_sparse_shape(x):
+    if isinstance(x, CSMatrixType):
+        return lambda x: x.shape
+
+
+@overload_attribute(CSMatrixType, "ndim")
+def overload_sparse_ndim(inst):
+
+    if not isinstance(inst, CSMatrixType):
+        return
+
+    def ndim(inst):
+        return 2
+
+    return ndim
+
+
+@intrinsic
+def _sparse_copy(typingctx, inst, data, indices, indptr, shape):
+    def _construct(context, builder, sig, args):
+        typ = sig.return_type
+        struct = cgutils.create_struct_proxy(typ)(context, builder)
+        _, data, indices, indptr, shape = args
+        struct.data = data
+        struct.indices = indices
+        struct.indptr = indptr
+        struct.shape = shape
+        return impl_ret_borrowed(context, builder, sig.return_type, struct._getvalue(),)
+
+    sig = inst(inst, inst.data, inst.indices, inst.indptr, inst.shape)
+
+    return sig, _construct
+
+
+@overload_method(CSMatrixType, "copy")
+def overload_sparse_copy(inst):
+
+    if not isinstance(inst, CSMatrixType):
+        return
+
+    def copy(inst):
+        return _sparse_copy(
+            inst, inst.data.copy(), inst.indices.copy(), inst.indptr.copy(), inst.shape
+        )
+
+    return copy

--- a/hdc/algo/vendor/numba_scipy/sparse.py
+++ b/hdc/algo/vendor/numba_scipy/sparse.py
@@ -16,7 +16,7 @@ try:
 except ImportError:
     from numba.errors import NumbaWarning
 
-    class NumbaExperimentalFeatureWarning(NumbaWarning):
+    class NumbaExperimentalFeatureWarning(NumbaWarning):  # type: ignore
         pass
 
 

--- a/hdc/algo/vendor/numba_scipy/special/__init__.py
+++ b/hdc/algo/vendor/numba_scipy/special/__init__.py
@@ -1,0 +1,3 @@
+from . import overloads as _overloads
+
+_overloads.add_overloads()

--- a/hdc/algo/vendor/numba_scipy/special/overloads.py
+++ b/hdc/algo/vendor/numba_scipy/special/overloads.py
@@ -1,0 +1,23 @@
+import numba
+import scipy.special as sc
+
+from . import signatures
+
+
+def choose_kernel(name, all_signatures):
+
+    def choice_function(*args):
+        for signature in all_signatures:
+            if args == signature:
+                f = signatures.name_and_types_to_pointer[(name, *signature)]
+                return lambda *args: f(*args)
+
+    return choice_function
+
+
+def add_overloads():
+    for name, all_signatures in signatures.name_to_numba_signatures.items():
+        sc_function = getattr(sc, name)
+        numba.extending.overload(sc_function)(
+            choose_kernel(name, all_signatures)
+        )

--- a/hdc/algo/vendor/numba_scipy/special/signatures.py
+++ b/hdc/algo/vendor/numba_scipy/special/signatures.py
@@ -1,0 +1,96 @@
+import collections
+import ctypes
+import re
+
+import numba
+import scipy.special.cython_special as cysc
+from numba.extending import get_cython_function_address
+
+CYTHON_TO_NUMBA = {
+    'double': numba.types.float64,
+    'float': numba.types.float32,
+    'long': numba.types.long_,
+}
+
+NUMBA_TO_CTYPES = {
+    numba.types.float64: ctypes.c_double,
+    numba.types.float32: ctypes.c_float,
+    numba.types.long_: ctypes.c_long,
+}
+
+
+def parse_capsule_name(capsule):
+    # There isn't a Python equivalent to `PyCapsule_GetName`, so
+    # resort to a hacky method for finding the signature.
+    match = re.match(
+        '<capsule object "(?P<signature>.+)" at 0x[A-Fa-f0-9]+>',
+        str(capsule),
+    )
+    if match is None:
+        raise ValueError('Unexpected capsule name {}'.format(capsule))
+
+    signature = match.group('signature')
+    match = re.match('(?P<return_type>.+) \\((?P<arg_types>.+)\\)', signature)
+    if match is None:
+        raise ValueError('Unexpected signature {}'.format(signature))
+
+    args = [
+        arg_type for arg_type in match.group('arg_types').split(', ')
+        if arg_type != 'int __pyx_skip_dispatch'
+    ]
+    return [match.group('return_type')] + args
+
+
+def de_mangle_function_name(mangled_name):
+    match = re.match('(__pyx_fuse(_[0-9])*)?(?P<name>.+)', mangled_name)
+    if match is None:
+        raise ValueError('Unexpected mangled name {}'.format(mangled_name))
+
+    return match.group('name')
+
+
+def get_signatures_from_pyx_capi():
+    signature_to_pointer = {}
+
+    for mangled_name, capsule in cysc.__pyx_capi__.items():
+        numba_signature = [
+            CYTHON_TO_NUMBA.get(t) for t in parse_capsule_name(capsule)
+        ]
+        if any(t is None for t in numba_signature):
+            # We don't know how to handle this kernel yet.
+            continue
+
+        signature_to_pointer[(mangled_name, *numba_signature)] = capsule
+
+    return signature_to_pointer
+
+
+def generate_signatures_dicts(signature_to_pointer):
+    name_to_numba_signatures = collections.defaultdict(list)
+    name_and_types_to_pointer = {}
+    for mangled_name, *signature in signature_to_pointer.keys():
+        name = de_mangle_function_name(mangled_name)
+        name_to_numba_signatures[name].append(
+            tuple(signature[1:])
+        )
+
+        key = (name,) + tuple(signature[1:])
+
+        address = (
+            get_cython_function_address('scipy.special.cython_special', mangled_name)
+        )
+        ctypes_signature = [NUMBA_TO_CTYPES[t] for t in signature]
+        ctypes_cast = (
+            ctypes.CFUNCTYPE(*ctypes_signature)
+        )
+        name_and_types_to_pointer[key] = ctypes_cast(address)
+
+    name_to_numba_signatures = {
+        name: tuple(signatures)
+        for name, signatures in name_to_numba_signatures.items()
+    }
+    return name_to_numba_signatures, name_and_types_to_pointer
+
+
+signature_to_pointer = get_signatures_from_pyx_capi()
+name_to_numba_signatures, name_and_types_to_pointer = generate_signatures_dicts(signature_to_pointer)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,11 +26,20 @@ exclude = '''
   | _build
   | build
   | dist
+  | hdc/algo/vendor
 )/
 '''
 
 [tool.isort]
 profile = "black"
+
+[tool.pylint.main]
+ignore-paths = [
+   "hdc/algo/vendor/*"
+]
+extension-pkg-allow-list = [
+  "scipy.special"
+]
 
 [tool.pylint.messages_control]
 max-line-length = 99
@@ -49,3 +58,6 @@ disable = [
   "wrong-import-order",
   "unnecessary-lambda-assignment",
 ]
+
+[tool.pydocstyle]
+match-dir = "(?!vendor).*"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
-numba-scipy==0.3.1
-scipy==1.7.3
-numba==0.57.0
-numpy==1.22.4
-xarray==2023.5.0
-
+scipy
+numba
+numpy
+xarray
 dask[array]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name =hdc-algo 
+name = hdc-algo
 description = xarray tools for seasonal monitor
 version = attr: hdc.algo._version.__version__
 author = WFP-VAM
@@ -43,7 +43,6 @@ test =
     pytest
 stats =
     scipy
-    numba-scipy
 
 [options.packages.find]
 include =
@@ -52,3 +51,7 @@ include =
 [aliases]
 # Define setup.py command aliases here
 test = pytest
+
+[options.entry_points]
+numba_extensions =
+  init = hdc.algo.vendor.numba_scipy:_init_extension


### PR DESCRIPTION
As discussed before, vendoring in numba-scipy code to avoid unnecessarily old constraints on scipy and as a result old numpy.

I tried to keep edits to a minimum in the vendored code, but could not get mypy to ignore the file so had to add `type: ignore` in there.