### PR TITLE
Logical operators for Dekad

### DIFF
--- a/hdc/algo/dekad.py
+++ b/hdc/algo/dekad.py
@@ -72,20 +72,44 @@ class Dekad:
         return hash(self._dkd)
 
     def __eq__(self, other: object) -> bool:
-        """Check equality with other Dekad or a string."""
-        if isinstance(other, str):
-            return str(self) == other
-        if isinstance(other, Dekad):
-            return self._dkd == other._dkd
-        return False
+        """Check equality with other Dekad, string or int."""
+        if isinstance(other, (str, int, datetime, date)):
+            other = Dekad(other)
+        if not isinstance(other, Dekad):
+            return NotImplemented
+        return self._dkd == other._dkd
 
-    def __lt__(self, other: object) -> bool:
-        """Check for less than inequality with other Dekad or a string."""
-        if isinstance(other, str):
-            return str(self) < other
-        if isinstance(other, Dekad):
-            return self._dkd < other._dkd
-        return False
+    def __lt__(self, other: Union[str, int, datetime, date, "Dekad"]) -> bool:
+        """Check for less than inequality with other Dekad, string or int."""
+        if isinstance(other, (str, int, datetime, date)):
+            other = Dekad(other)
+        if not isinstance(other, Dekad):
+            return NotImplemented
+        return self._dkd < other._dkd
+
+    def __gt__(self, other: Union[str, int, datetime, date, "Dekad"]) -> bool:
+        """Check for greater than inequality with other Dekad, string or int."""
+        if isinstance(other, (str, int, datetime, date)):
+            other = Dekad(other)
+        if not isinstance(other, Dekad):
+            return NotImplemented
+        return self._dkd > other._dkd
+
+    def __le__(self, other: Union[str, int, datetime, date, "Dekad"]) -> bool:
+        """Check for less than or equal inequality with other Dekad, string or int."""
+        if isinstance(other, (str, int, datetime, date)):
+            other = Dekad(other)
+        if not isinstance(other, Dekad):
+            return NotImplemented
+        return self._dkd <= other._dkd
+
+    def __ge__(self, other: Union[str, int, datetime, date, "Dekad"]) -> bool:
+        """Check for greater than or equal inequality with other Dekad, string or int."""
+        if isinstance(other, (str, int, datetime, date)):
+            other = Dekad(other)
+        if not isinstance(other, Dekad):
+            return NotImplemented
+        return self._dkd >= other._dkd
 
     @property
     def start_date(self) -> datetime:

--- a/hdc/algo/dekad.py
+++ b/hdc/algo/dekad.py
@@ -79,6 +79,14 @@ class Dekad:
             return self._dkd == other._dkd
         return False
 
+    def __lt__(self, other: object) -> bool:
+        """Check for less than inequality with other Dekad or a string."""
+        if isinstance(other, str):
+            return str(self) < other
+        if isinstance(other, Dekad):
+            return self._dkd < other._dkd
+        return False
+
     @property
     def start_date(self) -> datetime:
         """Start date as python ``datetime``."""

--- a/tests/test_dekad.py
+++ b/tests/test_dekad.py
@@ -1,5 +1,7 @@
 from datetime import date, datetime, timedelta
 
+import pytest
+
 from hdc.algo.dekad import Dekad
 
 # pylint: disable=use-implicit-booleaness-not-comparison
@@ -23,11 +25,15 @@ def test_dekad():
     assert Dekad(datetime(2021, 1, 1)) == "202101d1"
     assert Dekad(datetime(2021, 12, 11)) == "202112d2"
 
+    # Test equality
     assert Dekad("199912d3") == "199912d3"
     assert Dekad("199912d3") == Dekad(2000 * 36 - 1)
+    assert Dekad("202110d3") == 2021 * 36 + 3 * (10 - 1) + (3 - 1)
+    assert Dekad(Dekad("199912d3")) == Dekad("199912d3")
     assert (Dekad("200012d3") == []) is False
-    assert len(set([Dekad("20211221")] * 10)) == 1
 
+    # Hashing and representation
+    assert len(set([Dekad("20211221")] * 10)) == 1
     assert str(Dekad("199912d3")) == "199912d3"
     assert repr(Dekad("199912d3")) == 'Dekad("199912d3")'
 
@@ -60,3 +66,24 @@ def test_dekad():
     assert Dekad("202202d1").ndays == 10
     assert Dekad("202202d3").ndays == 8
     assert Dekad("202002d3").ndays == 9
+
+    # Test inequalities
+    assert Dekad("202202d3") < Dekad(date(2022, 3, 28))
+    assert Dekad("202202d3") < date(2022, 3, 28)
+    assert Dekad("202110d3") < "202212d3"
+    assert Dekad("202110d3") < 2021 * 36 + 3 * (11 - 1) + (3 - 1)
+
+    assert Dekad("202202d3") > Dekad(date(2019, 3, 28))
+    assert Dekad("202202d3") > datetime(2019, 3, 28)
+    assert Dekad("202110d3") > "201912d3"
+    assert Dekad("202110d3") > 2019 * 36 + 3 * (11 - 1) + (3 - 1)
+
+    assert Dekad("202202d3") >= Dekad(date(2022, 2, 28))
+    assert Dekad("202202d3") >= date(2022, 2, 28)
+    assert Dekad("202110d3") >= "202110d3"
+    assert Dekad("202111d3") >= 2021 * 36 + 3 * (10 - 1) + (3 - 1)
+
+    assert Dekad("202202d3") <= Dekad(date(2023, 2, 28))
+    assert Dekad("202202d3") <= date(2023, 2, 28)
+    assert Dekad("202110d3") <= "202110d3"
+    assert Dekad("202110d3") <= 2021 * 36 + 3 * (10 - 1) + (3 - 1)


### PR DESCRIPTION
As per title. Among the use cases is allowing `groupby`, eg.

```
# Create new dimenions mapping date to dekad
da['dekad'] = da.time.to_index().map(lambda x: Dekad(x).start_date)

# Use groupby for aggregation
da_agg = da.groupby('dekad').mean()
da_agg = da_agg.rename({'dekad':'time'})
```