### PR TITLE
`hdc-algo` utils & `linspace`

### DIFF
--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -22,7 +22,7 @@ jobs:
   conda:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Conda environment with Micromamba
         uses: mamba-org/setup-micromamba@v1
@@ -77,7 +77,7 @@ jobs:
           ls -lh pkgs/
  
       - name: Upload results (artifact)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pkgs
           path: pkgs

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,7 +11,7 @@ jobs:
       cache-path: ${{ steps.cfg.outputs.cache-path }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -24,7 +24,7 @@ jobs:
           echo "cache-key=${cache_key}" >> $GITHUB_OUTPUT
           echo "cache-path=${cache_path}" >> $GITHUB_OUTPUT
       - name: cache deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: py_cache
         with:
           path: ${{ steps.cfg.outputs.cache-path }}
@@ -51,9 +51,9 @@ jobs:
       - pyenv
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Get Python Env from Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: ${{ needs.pyenv.outputs.cache-key }}
           path: ${{ needs.pyenv.outputs.cache-path }}
@@ -74,9 +74,9 @@ jobs:
       - pyenv
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Get Python Env from Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: ${{ needs.pyenv.outputs.cache-key }}
           path: ${{ needs.pyenv.outputs.cache-path }}
@@ -100,9 +100,9 @@ jobs:
       - black
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Get Python Env from Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: ${{ needs.pyenv.outputs.cache-key }}
           path: ${{ needs.pyenv.outputs.cache-path }}
@@ -114,7 +114,7 @@ jobs:
         env:
           py_path: ${{ needs.pyenv.outputs.cache-path }}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: wheels_cache
         with:
           path: ./wheels
@@ -150,7 +150,7 @@ jobs:
           python setup.py sdist -d wheels
 
       - name: Upload results (artifact)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: wheels
@@ -162,9 +162,9 @@ jobs:
       - black
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Get Python Env from Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: ${{ needs.pyenv.outputs.cache-key }}
           path: ${{ needs.pyenv.outputs.cache-path }}
@@ -190,9 +190,9 @@ jobs:
       - wheels
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Get Python Env from Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: ${{ needs.pyenv.outputs.cache-key }}
           path: ${{ needs.pyenv.outputs.cache-path }}
@@ -205,7 +205,7 @@ jobs:
           py_path: ${{ needs.pyenv.outputs.cache-path }}
 
       - name: Get Wheels
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: wheels
           path: wheels

--- a/.github/workflows/publish-s3.yaml
+++ b/.github/workflows/publish-s3.yaml
@@ -22,10 +22,11 @@ jobs:
           key: wheels-${{ github.sha }}
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_S3_UPLOAD_ROLE }}
           aws-region: eu-central-1
+          mask-aws-account-id: true
 
       - name: upload wheels to S3
         run: |

--- a/.github/workflows/publish-s3.yaml
+++ b/.github/workflows/publish-s3.yaml
@@ -14,8 +14,8 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
         id: wheels_cache
         with:
           path: ./wheels

--- a/hdc/algo/__init__.py
+++ b/hdc/algo/__init__.py
@@ -1,4 +1,5 @@
 """Seasonal Monitoring Algorithms."""
+
 # isort: skip_file
 from ._version import __version__
 

--- a/hdc/algo/_version.py
+++ b/hdc/algo/_version.py
@@ -1,2 +1,3 @@
 """Version only in this file."""
+
 __version__ = "0.3.1"

--- a/hdc/algo/_version.py
+++ b/hdc/algo/_version.py
@@ -1,3 +1,3 @@
 """Version only in this file."""
 
-__version__ = "0.3.1"
+__version__ = "0.4.0"

--- a/hdc/algo/accessors.py
+++ b/hdc/algo/accessors.py
@@ -1,4 +1,5 @@
 """Xarray Accesor classes."""
+
 from typing import Iterable, List, Optional, Union
 from warnings import warn
 
@@ -119,6 +120,10 @@ class Period(AccessorTimeBase):
     @property
     def raw(self):
         return self._tseries.apply(lambda x: self._period_cls(x).raw).to_xarray()
+
+    @property
+    def linspace(self):
+        return self.yidx - 1
 
 
 @xarray.register_dataset_accessor("dekad")

--- a/hdc/algo/dekad.py
+++ b/hdc/algo/dekad.py
@@ -1,4 +1,5 @@
 """Dekad helper class."""
+
 from datetime import date, datetime, timedelta
 from typing import Tuple, Union, overload
 

--- a/hdc/algo/ops/__init__.py
+++ b/hdc/algo/ops/__init__.py
@@ -1,4 +1,5 @@
 """Numba implementations."""
+
 from .autocorr import autocorr, autocorr_1d, autocorr_tyx
 from .lroo import lroo
 from .tinterpolate import tinterpolate

--- a/hdc/algo/ops/autocorr.py
+++ b/hdc/algo/ops/autocorr.py
@@ -1,4 +1,5 @@
 """Lag-1 autocorrelations."""
+
 from numba import njit
 from numba.core.types import float32, float64, int64
 from numpy import isnan, zeros

--- a/hdc/algo/ops/lroo.py
+++ b/hdc/algo/ops/lroo.py
@@ -1,4 +1,5 @@
 """Calculate the longest run of ones inside a 1d array."""
+
 import numpy as np
 from numba import guvectorize
 

--- a/hdc/algo/ops/stats.py
+++ b/hdc/algo/ops/stats.py
@@ -1,4 +1,5 @@
 """Numba accelerated statistical funtions."""
+
 from math import erf, log, sqrt
 
 

--- a/hdc/algo/ops/tinterpolate.py
+++ b/hdc/algo/ops/tinterpolate.py
@@ -1,4 +1,5 @@
 """Interpolation numba functions."""
+
 from numba import guvectorize
 from numba.core.types import float64, int16, int32, uint8
 

--- a/hdc/algo/ops/whit.py
+++ b/hdc/algo/ops/whit.py
@@ -1,4 +1,5 @@
 """Numba accelerated Whittaker functions."""
+
 # pyright: reportGeneralTypeIssues=false
 # pylint: disable=C0103,C0301,E0401,R0912,R0913,R0914,R0915,too-many-lines
 from math import log, pow, sqrt  # pylint: disable=W0622

--- a/hdc/algo/ops/ws2d.py
+++ b/hdc/algo/ops/ws2d.py
@@ -1,4 +1,5 @@
 """Whittaker filter with differences of 2nd order for a 1d array."""
+
 from numba import njit
 from numpy import zeros
 

--- a/hdc/algo/ops/ws2dgu.py
+++ b/hdc/algo/ops/ws2dgu.py
@@ -1,4 +1,5 @@
 """Whittaker smoother with fixed lambda (S)."""
+
 import numpy as np
 from numba import guvectorize
 from numba.core.types import float64, int16

--- a/hdc/algo/ops/ws2doptv.py
+++ b/hdc/algo/ops/ws2doptv.py
@@ -1,4 +1,5 @@
 """Whittaker filter V-curve optimization os S."""
+
 from math import log, sqrt
 
 import numpy as np

--- a/hdc/algo/ops/ws2doptvp.py
+++ b/hdc/algo/ops/ws2doptvp.py
@@ -1,4 +1,5 @@
 """Whittaker filter V-curve optimization of S and asymmetric weights."""
+
 # pyright: reportGeneralTypeIssues=false
 from math import log, sqrt
 

--- a/hdc/algo/ops/ws2doptvplc.py
+++ b/hdc/algo/ops/ws2doptvplc.py
@@ -3,6 +3,7 @@ Whittaker filter V-curve optimization of S, asymmetric weights and srange from a
 
 numba implementations.
 """
+
 # pyright: reportGeneralTypeIssues=false
 from math import log, sqrt
 

--- a/hdc/algo/ops/ws2dpgu.py
+++ b/hdc/algo/ops/ws2dpgu.py
@@ -1,4 +1,5 @@
 """Whittaker smoother with asymmetric smoothing and fixed lambda (S)."""
+
 import numpy as np
 from numba import guvectorize
 from numba.core.types import float64, int16

--- a/hdc/algo/ops/ws2dwcvp.py
+++ b/hdc/algo/ops/ws2dwcvp.py
@@ -1,4 +1,5 @@
 """Whittaker filter V-curve optimization of S and asymmetric weights."""
+
 # pyright: reportGeneralTypeIssues=false
 import numpy as np
 from numba import guvectorize, jit

--- a/hdc/algo/ops/zonal.py
+++ b/hdc/algo/ops/zonal.py
@@ -1,4 +1,5 @@
 """Numba accelerated zonal statistics."""
+
 from numba import njit
 import numpy as np
 

--- a/hdc/algo/utils.py
+++ b/hdc/algo/utils.py
@@ -1,10 +1,12 @@
+"""hcd-algo utility functions."""
+
 from typing import List, Tuple
 
 import numpy as np
 
 
 def to_linspace(x) -> Tuple[np.ndarray, List[int]]:
-    """Maps input array to linear space.
+    """Map input array to linear space.
 
     Returns array with linear index (0 - n-1) and list of
     original keys matching the indices.

--- a/hdc/algo/utils.py
+++ b/hdc/algo/utils.py
@@ -1,0 +1,21 @@
+from typing import List, Tuple
+
+import numpy as np
+
+
+def to_linspace(x) -> Tuple[np.ndarray, List[int]]:
+    """Maps input array to linear space.
+
+    Returns array with linear index (0 - n-1) and list of
+    original keys matching the indices.
+    """
+    keys = np.unique(x)
+    keys.sort()
+    values = np.arange(keys.size)
+
+    idx = np.searchsorted(keys, x.ravel()).reshape(x.shape)
+    idx[idx == keys.size] = 0
+    mask = keys[idx] == x.data
+    new_pix = np.where(mask, values[idx], 0)
+
+    return new_pix, list(keys)

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,7 +3,7 @@ twine
 pytest
 pytest-runner
 pytest-cov
-black
+black>=24.1.0
 pylint==2.17.2
 astroid==2.15.3
 pydocstyle

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -1,4 +1,5 @@
 """Tests for xarray accessors"""
+
 # pylint: disable=redefined-outer-name,unused-import,no-member,no-name-in-module,missing-function-docstring
 # pyright: reportGeneralTypeIssues=false
 
@@ -71,6 +72,11 @@ def test_period_idx_dekad(darr):
 def test_period_yidx_dekad(darr):
     assert isinstance(darr.time.dekad.yidx, xr.DataArray)
     np.testing.assert_array_equal(darr.time.dekad.yidx, [1, 2, 3, 3, 4])
+
+
+def test_period_yidx_linspace_dekad(darr):
+    assert isinstance(darr.time.dekad.linspace, xr.DataArray)
+    np.testing.assert_array_equal(darr.time.dekad.linspace, [0, 1, 2, 2, 3])
 
 
 def test_period_ndays_dekad(darr):

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -1,4 +1,5 @@
 """Tests for pixel alogrithms"""
+
 # pylint: disable=no-name-in-module,redefined-outer-name,no-value-for-parameter
 # pyright: reportGeneralTypeIssues=false
 import numpy as np

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,29 @@
+"""Test utility functions."""
+
+import numpy as np
+import pytest
+
+from hdc.algo.utils import to_linspace
+
+
+@pytest.mark.parametrize(
+    "input_array, expected_output",
+    [
+        # Test case 1: Array with unique values
+        (
+            np.array([[1, 2, 3], [4, 5, 6]]),
+            (np.array([[0, 1, 2], [3, 4, 5]]), [1, 2, 3, 4, 5, 6]),
+        ),
+        # Test case 2: Array with repeated values
+        (
+            np.array([[1, 2, 2], [3, 4, 4]]),
+            (np.array([[0, 1, 1], [2, 3, 3]]), [1, 2, 3, 4]),
+        ),
+        # Test case 3: Empty array
+        (np.array([]), (np.array([]), [])),
+    ],
+)
+def test_to_linspace(input_array, expected_output):
+    x, y = to_linspace(input_array)
+    np.testing.assert_equal(x, expected_output[0])
+    np.testing.assert_equal(y, expected_output[1])


### PR DESCRIPTION
This PR adds a `utils` module for simple utility function that shouldn't necessarily go into ops.

Now I've added `to_linspace` which has functionality copied over from `hdc-tools`, to map an input array into linear space. This is useful for using the grouped aggregations introduced in `0.3.0`

I've also extended the `PeriodAccessors` which a `linspace` property, as this is likely one major usecase. In this specific case, the linear array is just the yearly index with 0-index. Still, IMO it's useful to abstract this away so that can be used as direct input.
 
## Edit:
PR also includes:

- bump and application of new black version
- bump of github actions
- bump of S3 credential action from `v2` to `v4` - default cred timeout is now 1h (should be plenty), and need to verbosely set AWS account ID to masked