### PR TITLE
Handle NODATA in SPI

### DIFF
--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -96,7 +96,7 @@ def test_gammafit(ts):
     assert parameters == pytest.approx((1.083449238500003, 0.9478709674697126))
 
 
-def test_gammastd(ts):
+def test_gammastd_yxt(ts):
     xspi = gammastd_yxt.py_func(ts.reshape(1, 1, -1), -9999)
     assert xspi.shape == (1, 1, 10)
     np.testing.assert_array_equal(
@@ -114,9 +114,33 @@ def test_gammastd(ts):
     )
 
 
+def test_gammastd_nodata(ts):
+    nodata = -9999.0
+    ts_nodata = [*ts]
+    ts_nodata[2] = nodata
+    xspi = gammastd.py_func(ts_nodata, nodata, 0, 10)
+    valid_ix = xspi != nodata
+    xspi[valid_ix] = xspi[valid_ix] * 1000
+
+    np.testing.assert_array_equal(
+        xspi.round(),
+        [
+            -312.0,
+            1655.0,
+            nodata,
+            257.0,
+            -1001.0,
+            -1001.0,
+            -1560.0,
+            1113.0,
+            263.0,
+            554.0,
+        ],
+    )
+
+
 def test_gammastd_nofit(ts):
     xspi = gammastd.py_func(ts, -9999, 0, len(ts), a=1, b=2)
-    xspi
     np.testing.assert_array_equal(
         (xspi * 1000).round(),
         [

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -116,9 +116,8 @@ def test_gammastd(ts):
 
 def test_gammastd_nodata(ts):
     nodata = -9999.0
-    ts_nodata = [*ts]
-    ts_nodata[2] = nodata
-    xspi = gammastd.py_func(ts_nodata, nodata, 0, 10)
+    ts[2] = nodata
+    xspi = gammastd.py_func(ts, nodata, 0, 10)
     valid_ix = xspi != nodata
     xspi[valid_ix] = xspi[valid_ix] * 1000
 


### PR DESCRIPTION
This PR modifies `gammastd` and `gammastd_yxt` to handle `nodata` values. `nodata` was already passed in but not handled. 

- do not use `nodata` to compute the probability of zeros in `gammastd`
- return `nodata` for `nodata` input
- update `gammastd_yxt` accordingly, inspired by gammastd_grp
- add a test with a `nodata` value in the input ts